### PR TITLE
515ify - fix remaining C&D deletes

### DIFF
--- a/code/game/objects/items/devices/personal_data_transmitter.dm
+++ b/code/game/objects/items/devices/personal_data_transmitter.dm
@@ -139,6 +139,7 @@
 
 /obj/item/device/pdt_locator_tube/Destroy()
 	linked_bracelet = null
+	QDEL_NULL(battery)
 	return ..()
 
 /obj/item/clothing/accessory/pdt_bracelet

--- a/code/game/objects/items/reagent_containers/food/snacks.dm
+++ b/code/game/objects/items/reagent_containers/food/snacks.dm
@@ -2745,6 +2745,10 @@
 	var/list/boxes = list() // If the boxes are stacked, they come here
 	var/boxtag = ""
 
+/obj/item/pizzabox/Destroy(force)
+	QDEL_NULL(pizza)
+	return ..()
+
 /obj/item/pizzabox/update_icon()
 
 	overlays = list()

--- a/code/modules/cm_phone/phone.dm
+++ b/code/modules/cm_phone/phone.dm
@@ -362,7 +362,7 @@ GLOBAL_LIST_EMPTY_TYPED(transmitters, /obj/structure/transmitter)
 			qdel(attached_to)
 		else
 			attached_to.attached_to = null
-			attached_to = null
+		attached_to = null
 
 	GLOB.transmitters -= src
 	SStgui.close_uis(src)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -503,13 +503,13 @@ As sniper rifles have both and weapon mods can change them as well. ..() deals w
 
 	if(slot in list(WEAR_L_HAND, WEAR_R_HAND))
 		set_gun_user(user)
-		if(HAS_TRAIT_FROM_ONLY(src, TRAIT_GUN_LIGHT_DEACTIVATED, user))
+		if(HAS_TRAIT_FROM_ONLY(src, TRAIT_GUN_LIGHT_DEACTIVATED, WEAKREF(user)))
 			force_light(on = TRUE)
-			REMOVE_TRAIT(src, TRAIT_GUN_LIGHT_DEACTIVATED, user)
+			REMOVE_TRAIT(src, TRAIT_GUN_LIGHT_DEACTIVATED, WEAKREF(user))
 	else
 		set_gun_user(null)
 		force_light(on = FALSE)
-		ADD_TRAIT(src, TRAIT_GUN_LIGHT_DEACTIVATED, user)
+		ADD_TRAIT(src, TRAIT_GUN_LIGHT_DEACTIVATED, WEAKREF(user))
 
 	return ..()
 

--- a/code/modules/projectiles/guns/specialist/launcher/launcher.dm
+++ b/code/modules/projectiles/guns/specialist/launcher/launcher.dm
@@ -38,6 +38,10 @@
 			new preload(cylinder)
 		update_icon()
 
+/obj/item/weapon/gun/launcher/Destroy(force)
+	QDEL_NULL(cylinder)
+	return ..()
+
 /obj/item/weapon/gun/launcher/verb/toggle_draw_mode()
 	set name = "Switch Storage Drawing Method"
 	set category = "Object"


### PR DESCRIPTION
Doesn't fix OD Linter error, i have no idea what causes this unless it just doesn't implement 515 NAMEOF_STATIC syntax

I didn't understand what you wanted to do with TRAIT_GUN_LIGHT_DEACTIVATED so just WEAKREF'd it